### PR TITLE
Update REST DataTypes to allow for use of 'reference transactions'

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -176,11 +176,47 @@ module PayPal::SDK
         include RequestDataType
       end
 
-      class BillingAgreementToken < Base
+      class BillingAgreement < Base
         def self.load_members
+          object_of :id, String
+          object_of :token_id, String
+          object_of :state, String
+          object_of :description, String
+          object_of :payer, Payer
+          object_of :plan, Plan
+          object_of :create_time, String
+          object_of :update_time, String
+          array_of  :links, Links
         end
 
         include RequestDataType
+
+        def create()
+          path = "v1/billing-agreements/agreements"
+          response = api.post(path, self.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
+      end
+
+      class BillingAgreementToken < Base
+        def self.load_members
+          object_of :description, String
+          array_of :links, Links
+          object_of :payer, Payer
+          object_of :plan, Plan
+          object_of :shipping_address, ShippingAddress
+          object_of :token_id, String
+        end
+
+        include RequestDataType
+
+        def create()
+          path = "v1/billing-agreements/agreement-tokens"
+          response = api.post(path, self.to_hash, http_header)
+          self.merge!(response)
+          success?
+        end
       end
 
       class CountryCode < Base
@@ -304,6 +340,7 @@ module PayPal::SDK
         def self.load_members
           object_of :credit_card, CreditCard
           object_of :credit_card_token, CreditCardToken
+          object_of :billing, Billing
         end
       end
 

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -443,5 +443,24 @@ describe "Payments" do
 
     end
 
+    describe 'BillingAgreement' do
+      it "Create" do
+        billing_agreement = BillingAgreement.new({
+          "token_id" => "BA-123"
+        })
+        billing_agreement.create
+        expect(billing_agreement.error).to be_nil
+        expect(billing_agreement.id).not_to be_nil
+      end
+    end
+
+    describe 'BillingAgreementToken' do
+      it "Create" do
+        billing_agreement_token = BillingAgreementToken.new
+        billing_agreement_token.create
+        expect(billing_agreement_token.error).to be_nil
+        expect(billing_agreement_token.token_id).not_to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This gem is currently lacking the ability to make use of PayPal's ['reference transactions' API](https://developer.paypal.com/docs/limited-release/reference-transactions/#integration-steps). 

This PR adds the ability to create `BillingAgreement`s and `BillingAgreementToken`s, which are required for this.