### PR TITLE
Aidanmalone/ch47111/update paypal ruby sdk to accept application

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -70,6 +70,7 @@ module PayPal::SDK
           object_of :create_time, String
           object_of :update_time, String
           array_of  :links, Links
+          object_of :application_context, ApplicationContext
           object_of :note_to_payer, String
           array_of  :billing_agreement_tokens, String
           object_of :potential_payer_info, PotentialPayerInfo
@@ -709,6 +710,12 @@ module PayPal::SDK
           object_of :payment_options, PaymentOptions
         end
       end
+
+      class ApplicationContext < Base
+        def self.load_members
+          object_of :shipping_preference, String
+        end
+        end
 
       class CartBase < Base
         def self.load_members

--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -711,12 +711,6 @@ module PayPal::SDK
         end
       end
 
-      class ApplicationContext < Base
-        def self.load_members
-          object_of :shipping_preference, String
-        end
-        end
-
       class CartBase < Base
         def self.load_members
           object_of :amount, Amount
@@ -2224,6 +2218,12 @@ module PayPal::SDK
           object_of :method, String
           object_of :encType, String
           object_of :schema, HyperSchema
+        end
+      end
+
+      class ApplicationContext < Base
+        def self.load_members
+          object_of :shipping_preference, String
         end
       end
 

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -451,25 +451,5 @@ describe "Payments" do
       end
 
     end
-
-    describe 'BillingAgreement' do
-      it "Create" do
-        billing_agreement = BillingAgreement.new({
-          "token_id" => "BA-123"
-        })
-        billing_agreement.create
-        expect(billing_agreement.error).to be_nil
-        expect(billing_agreement.id).not_to be_nil
-      end
-    end
-
-    describe 'BillingAgreementToken' do
-      it "Create" do
-        billing_agreement_token = BillingAgreementToken.new
-        billing_agreement_token.create
-        expect(billing_agreement_token.error).to be_nil
-        expect(billing_agreement_token.token_id).not_to be_nil
-      end
-    end
   end
 end

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -31,6 +31,9 @@ describe "Payments" do
 
   PaymentAttributesPayPal = {
         "intent" =>  "sale",
+        "application_context" => {
+          "shipping_preference": "NO_SHIPPING"
+        },
         "payer" =>  {
           "payment_method" =>  "paypal"
         },
@@ -46,6 +49,9 @@ describe "Payments" do
 
   FuturePaymentAttributes = {
         "intent" =>  "authorize",
+        "application_context" => {
+          "shipping_preference": "NO_SHIPPING"
+        },
         "payer" =>  {
           "payment_method" =>  "paypal" },
         "transactions" =>  [ {

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -6,6 +6,9 @@ describe "Payments" do
 
   PaymentAttributes = {
         "intent" =>  "sale",
+        "application_context" => {
+          "shipping_preference": "NO_SHIPPING"
+        },
         "payer" =>  {
           "payment_method" =>  "credit_card",
           "funding_instruments" =>  [ {


### PR DESCRIPTION
[Ticket](https://app.clubhouse.io/slicelife/story/47111/update-paypal-ruby-sdk-to-accept-application-context-with-shipping-preference-key-as-a-payment-parameter)

This allows the PayPal Ruby SDK to accept the application_context key for Payment requests. This key allows us to set a shipping preference, so as we can disable the ability to users to change their address through the PayPal Checkout process.