### PR TITLE
chore: replace 'master' with 'main' references

### DIFF
--- a/.releasinator.rb
+++ b/.releasinator.rb
@@ -3,7 +3,7 @@ configatron.product_name = "PayPal Ruby SDK"
 
 # List of items to confirm from the person releasing.  Required, but empty list is ok.
 configatron.prerelease_checklist_items = [  
-  "Sanity check the master branch."
+  "Sanity check the main branch."
 ]
 
 def validate_version_match()


### PR DESCRIPTION
> [!WARNING]
> This PR is part of an initiative to change references from 'master' to 'main'.
> 
> **It is highly advised that a human reviews all references before merging. This might not be a full set of changes that are needed.**
> 
> This PR updates references in the `.github` and `argocd` folders.
> 
> ## ⚠️ Remaining 'master' references found:
> 
> The following files still contain 'master' references that may need manual review:
> 
> - [`.releasinator.rb:6`](https://github.com/slicelife/PayPal-Ruby-SDK/blob/chore%2Fmaster-to-main/.releasinator.rb#L6)
> - [`README.md:1`](https://github.com/slicelife/PayPal-Ruby-SDK/blob/chore%2Fmaster-to-main/README.md#L1)
> - [`README.md:192`](https://github.com/slicelife/PayPal-Ruby-SDK/blob/chore%2Fmaster-to-main/README.md#L192)
> - [`README.md:195`](https://github.com/slicelife/PayPal-Ruby-SDK/blob/chore%2Fmaster-to-main/README.md#L195)
> 
> More information available at: [Confluence doc](https://mypizza.atlassian.net/wiki/spaces/DEVOPS/pages/6626803725/Branch+rename+from+master+to+main+in+GitHub)
